### PR TITLE
Issue #1 Private cycles are being shown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-darwin)
+      racc (~> 1.4)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -242,6 +244,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,5 +1,5 @@
 class CyclesController < ApplicationController
   def index
-    @cycles = Cycle.all
+    @cycles = Cycle.where(public_status: true)
   end
 end

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,5 +1,6 @@
 class CyclesController < ApplicationController
   def index
     @cycles = Cycle.where(public_status: true)
+    # @cycles = Cycle.all
   end
 end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -2,7 +2,6 @@ class Cycle < ApplicationRecord
   validates_presence_of :name
 
   def public?
-    !(piblic_status: true)
+    self.public_status === true
   end
-  
 end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,3 +1,8 @@
 class Cycle < ApplicationRecord
   validates_presence_of :name
+
+  def public?
+    !(piblic_status: true)
+  end
+  
 end

--- a/app/views/cycles/_cycle.html.erb
+++ b/app/views/cycles/_cycle.html.erb
@@ -1,3 +1,5 @@
 <div class="cycles-table__row">
-  <%= cycle.name %>
+  <%# <% if cycle.public? %>
+    <%= cycle.name %>
+  <%# <% end %>
 </div>

--- a/spec/models/cycle_spec.rb
+++ b/spec/models/cycle_spec.rb
@@ -13,4 +13,3 @@ RSpec.describe Cycle, type: :model do
     expect(cycle).not_to be_public
   end
 end
-# git add . && git commit -m "created spec againts the public? method, includes checks for public_status true and false"

--- a/spec/models/cycle_spec.rb
+++ b/spec/models/cycle_spec.rb
@@ -5,14 +5,12 @@ RSpec.describe Cycle, type: :model do
 
   it { should validate_presence_of (:name) }
 
-  # it "returns cycle, if public_status: true" 
-  #   # cycle = build(:cycle, public_status: true)
-  #   expect(cycle).to be_public
-  # end
+  it "expected to return cycle, only if public_status: true" do
+    cycle = create(:cycle, public_status: true)
+    expect(cycle).to be_public
 
-  # it "returns cycle, if public_status: false" 
-  #   # cycle = build(:cycle, public_status: false)
-  #   expect(cycle).not_to be_public
-  # end
-  # TODO spec if method returns only cycles with public_status: true, so index method in controller will have only public cycles
+    cycle = create(:cycle, public_status: false)
+    expect(cycle).not_to be_public
+  end
 end
+# git add . && git commit -m "created spec againts the public? method, includes checks for public_status true and false"

--- a/spec/models/cycle_spec.rb
+++ b/spec/models/cycle_spec.rb
@@ -4,4 +4,15 @@ RSpec.describe Cycle, type: :model do
   subject(:cycle) { create(:cycle) }
 
   it { should validate_presence_of (:name) }
+
+  # it "returns cycle, if public_status: true" 
+  #   # cycle = build(:cycle, public_status: true)
+  #   expect(cycle).to be_public
+  # end
+
+  # it "returns cycle, if public_status: false" 
+  #   # cycle = build(:cycle, public_status: false)
+  #   expect(cycle).not_to be_public
+  # end
+  # TODO spec if method returns only cycles with public_status: true, so index method in controller will have only public cycles
 end


### PR DESCRIPTION
Done:

- updated index to return only cycles with public_status: true
- created model method public? , we can use in views to check if cycle public, as alternative with @cycle = Cycle.all
- created specs to test against cycles with and without public_status: true

Note: I know I shouldn't push commented code, wanted to give alternative that might work in some cases.